### PR TITLE
Fix seven GUI bugs: ARM64 crash, bad imports, widget ranges, mesh viewer

### DIFF
--- a/src/surface_morphometrics_gui/experiment_manager.py
+++ b/src/surface_morphometrics_gui/experiment_manager.py
@@ -804,8 +804,8 @@ class ExperimentManager(QWidget):
         is set to the source's parent so the experiment dropdown picks
         up the new experiment.
         """
-        from widgets.cli_import_dialog import CliImportDialog
-        from utils.cli_import import execute_plan
+        from .widgets.cli_import_dialog import CliImportDialog
+        from .utils.cli_import import execute_plan
 
         template_data, template_path = self._load_config_template()
         dialog = CliImportDialog(

--- a/src/surface_morphometrics_gui/jobs/distance_tab.py
+++ b/src/surface_morphometrics_gui/jobs/distance_tab.py
@@ -151,8 +151,8 @@ class DistanceOrientationWidget(QWidget):
         settings.native.layout().setContentsMargins(3, 3, 3, 3)
 
         # Settings widgets
-        self.min_dist = widgets.FloatSpinBox(value=3.0, min=0.0, max=1000.0, step=0.1, label='Min Distance')
-        self.max_dist = widgets.FloatSpinBox(value=400.0, min=0.0, max=1000.0, step=0.1, label='Max Distance')
+        self.min_dist = widgets.FloatSpinBox(value=3.0, min=0.0, max=50000.0, step=0.1, label='Min Distance')
+        self.max_dist = widgets.FloatSpinBox(value=400.0, min=0.0, max=50000.0, step=0.1, label='Max Distance')
         self.tolerance = widgets.FloatSpinBox(value=0.1, min=0.0, max=1.0, step=0.01, label='Tolerance')
         self.verticality = widgets.CheckBox(value=True, label='Measure Verticality')
         self.relative_orientation = widgets.CheckBox(value=True, label='Measure Relative Orientation')

--- a/src/surface_morphometrics_gui/jobs/mesh_tab.py
+++ b/src/surface_morphometrics_gui/jobs/mesh_tab.py
@@ -58,7 +58,7 @@ class MeshGenerationWidget(QWidget):
         self.isotropic_remesh = widgets.CheckBox(value=False, label='Isotropic Remesh')
         self.simplify = widgets.CheckBox(value=False, label='Simplify Surface')
         self.max_triangles = widgets.SpinBox(value=300000, min=1000, max=1000000, label='Max Triangles')
-        self.extrapolation_distance = widgets.FloatSpinBox(value=1.5, min=0.1, max=10.0, step=0.1, label='Extrapolation Distance')
+        self.extrapolation_distance = widgets.FloatSpinBox(value=1.5, min=0.1, max=500.0, step=0.1, label='Extrapolation Distance')
         self.octree_depth = widgets.SpinBox(value=7, min=1, max=15, label='Octree Depth')
         self.point_weight = widgets.FloatSpinBox(value=0.7, min=0.1, max=1.0, step=0.1, label='Point Weight')
         self.neighbor_count = widgets.SpinBox(value=400, min=10, max=1000, label='Neighbor Count')

--- a/src/surface_morphometrics_gui/jobs/pycurv_tab.py
+++ b/src/surface_morphometrics_gui/jobs/pycurv_tab.py
@@ -42,7 +42,7 @@ class PyCurvWidget(QWidget):
         settings_container = widgets.Container(layout='vertical', labels=True)
         settings_container.native.layout().setSpacing(5)
         settings_container.native.layout().setContentsMargins(3, 3, 3, 3)
-        self.radius_hit_input = widgets.SpinBox(value=9, min=1, max=20, label='Radius Hit')
+        self.radius_hit_input = widgets.SpinBox(value=9, min=1, max=500, label='Radius Hit')
         self.min_component_input = widgets.SpinBox(value=30, min=1, max=1000, label='Min Component')
         self.exclude_borders_input = widgets.SpinBox(value=1, min=0, max=100, label='Exclude Borders')
         self.n_jobs_input = widgets.SpinBox(value=1, min=1, max=128, label='Concurrent Jobs (Parallel Files)')

--- a/src/surface_morphometrics_gui/main.py
+++ b/src/surface_morphometrics_gui/main.py
@@ -10,6 +10,29 @@ warnings.filterwarnings("ignore", message="Back buffer dpr of .* doesn't match .
 
 logging.basicConfig(level=logging.INFO)
 
+
+def _patch_status_checker_stack_size():
+    # On Apple Silicon (ARM64) the default QThread stack is ~544 KB.
+    # napari's StatusChecker thread calls numpy.linalg.inv(), which dispatches
+    # to OpenBLAS's dgetrf_parallel.  That routine allocates a frame far larger
+    # than 544 KB on ARM64, triggering ___chkstk_darwin → SIGBUS ("bus error").
+    # Increasing the stack to 8 MB avoids the overflow without changing behaviour.
+    from napari._qt.threads.status_checker import StatusChecker
+    from qtpy.QtCore import QThread
+
+    _orig_start = StatusChecker.start
+
+    def _start_with_large_stack(
+        self, priority: QThread.Priority = QThread.Priority.InheritPriority
+    ) -> None:
+        self.setStackSize(8 * 1024 * 1024)  # 8 MB; Qt default is ~544 KB on macOS ARM
+        _orig_start(self, priority)
+
+    StatusChecker.start = _start_with_large_stack
+
+
+_patch_status_checker_stack_size()
+
 from .jobs.mesh_tab import MeshGenerationWidget
 from .jobs.pycurv_tab import PyCurvWidget
 from .jobs.distance_tab import DistanceOrientationWidget

--- a/src/surface_morphometrics_gui/plugins/mesh_viewer.py
+++ b/src/surface_morphometrics_gui/plugins/mesh_viewer.py
@@ -238,9 +238,17 @@ class MeshViewer(QWidget):
         mesh_tuple = (vertices, faces, values)
 
         name = os.path.splitext(os.path.basename(filepath))[0]
-        metadata = {'source_vtp_path': filepath}
+        # Only tag VTP files as the source path; other formats (PLY, STL, OBJ)
+        # cannot be re-read by vtkXMLPolyDataReader and would cause an XML parse
+        # error at byte 0 when _initialize_vtp_layer tries to load them.
+        metadata = {'source_vtp_path': filepath} if ext == '.vtp' else {}
+
+        # Surface layers require 3D display mode; switch automatically.
+        if self.viewer.dims.ndisplay != 3:
+            self.viewer.dims.ndisplay = 3
 
         self.viewer.add_surface(mesh_tuple, name=name, metadata=metadata)
+        self.viewer.reset_view()
 
     def _is_vtp_surface_layer(self, layer):
         """Checks if a layer is a Surface derived from a VTP file."""
@@ -586,7 +594,10 @@ class MeshViewer(QWidget):
         # so that AO-darkened areas actually appear darker in the colormap.
         finite_values = new_values[np.isfinite(new_values)]
         if len(finite_values) > 0:
-            original_limits = (float(np.min(finite_values)), float(np.max(finite_values)))
+            lo, hi = float(np.min(finite_values)), float(np.max(finite_values))
+            if lo >= hi:
+                hi = lo + 1e-6  # napari requires strictly increasing contrast limits
+            original_limits = (lo, hi)
         else:
             original_limits = (0.0, 1.0)
 


### PR DESCRIPTION
During a test run on my mac book pro M1 I encounter several issues, for which this PR proposed some solution.

- main.py: increase napari StatusChecker QThread stack to 8 MB to prevent SIGBUS on Apple Silicon (ARM64) when numpy.linalg.inv() dispatches to OpenBLAS dgetrf_parallel, which exceeds Qt's default ~544 KB stack limit

- experiment_manager.py: fix ModuleNotFoundError in _import_cli_project by converting bare 'from widgets.' and 'from utils.' to relative imports

- jobs/mesh_tab.py: raise extrapolation_distance widget max 10 → 500 so
  angstrom-scale configs (e.g. extrapolation_distance: 15) load without error

- jobs/pycurv_tab.py: raise radius_hit widget max 20 → 500 so configs with
  radius_hit: 90 (Å-scale) load correctly instead of silently keeping default

- jobs/distance_tab.py: raise min_dist/max_dist widget max 1000 → 50000 so
  configs with maxdist: 4000 (Å-scale) load without ValueError

- plugins/mesh_viewer.py: three fixes:
  1. Only set source_vtp_path metadata for .vtp files; PLY/STL/OBJ were causing vtkXMLPolyDataReader to fail with "byte 0: syntax error"
  2. Switch viewer to 3D mode and call reset_view() after loading a mesh so surfaces are immediately visible instead of requiring manual camera reset
  3. Guard contrast limits against equal min/max (uniform scalar values such as the initial np.ones array) to prevent napari's "Sequence must be monotonically increasing" error during AO computation