### PR TITLE
Harden ARM64 StatusChecker stack patch + regression tests

### DIFF
--- a/src/surface_morphometrics_gui/main.py
+++ b/src/surface_morphometrics_gui/main.py
@@ -3,6 +3,7 @@ from magicgui import widgets
 from qtpy.QtWidgets import QTabWidget, QSizePolicy, QApplication
 from qtpy import QtCore
 import logging
+import sys
 import warnings
 
 # Filter out VisPy/macOS specific warnings that are harmless
@@ -17,8 +18,24 @@ def _patch_status_checker_stack_size():
     # to OpenBLAS's dgetrf_parallel.  That routine allocates a frame far larger
     # than 544 KB on ARM64, triggering ___chkstk_darwin → SIGBUS ("bus error").
     # Increasing the stack to 8 MB avoids the overflow without changing behaviour.
-    from napari._qt.threads.status_checker import StatusChecker
-    from qtpy.QtCore import QThread
+    #
+    # The small QThread stack is a macOS trait (~512 KB on Intel and Apple
+    # Silicon alike); Linux/Windows default to much larger stacks and don't hit
+    # this. The patch targets a private napari API, so it is gated to macOS and
+    # wrapped defensively: a napari version that moves StatusChecker must not
+    # break startup for everyone.
+    if sys.platform != "darwin":
+        return
+
+    try:
+        from napari._qt.threads.status_checker import StatusChecker
+        from qtpy.QtCore import QThread
+    except ImportError:
+        logging.warning(
+            "Could not patch napari StatusChecker stack size; "
+            "ARM64 SIGBUS workaround is inactive."
+        )
+        return
 
     _orig_start = StatusChecker.start
 

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -197,3 +197,55 @@ class TestBug10_TimeSleep:
         source = inspect.getsource(MeshViewer._setup_shading)
         assert "time.sleep" not in source, \
             "_setup_shading should not use time.sleep in UI thread"
+
+
+class TestBug11_CliImportRelativeImports:
+    """Bug #11: _import_cli_project used bare `from widgets.` / `from utils.`
+    imports, which raised ModuleNotFoundError for the installed package
+    (they only resolved when cwd happened to be on sys.path)."""
+
+    def test_import_cli_project_uses_relative_imports(self):
+        import experiment_manager
+        source = inspect.getsource(experiment_manager.ExperimentManager._import_cli_project)
+        assert "from widgets." not in source, \
+            "_import_cli_project must not use bare `from widgets.` import"
+        assert "from utils." not in source, \
+            "_import_cli_project must not use bare `from utils.` import"
+        assert "from .widgets." in source and "from .utils." in source, \
+            "_import_cli_project must use package-relative imports"
+
+    def test_cli_import_targets_are_importable(self):
+        # The modules the relative imports resolve to must actually exist.
+        from surface_morphometrics_gui.widgets.cli_import_dialog import CliImportDialog
+        from surface_morphometrics_gui.utils.cli_import import execute_plan
+        assert CliImportDialog is not None and execute_plan is not None
+
+
+class TestBug12_WidgetRangesClampAngstromConfigs:
+    """Bug #12: widget max ranges were below realistic angstrom-scale config
+    values, so loading e.g. radius_hit: 90 / maxdist: 4000 silently clamped to
+    the widget default (or raised ValueError) instead of taking effect."""
+
+    @pytest.mark.gui
+    def test_radius_hit_accepts_angstrom_scale(self, qapp):
+        from jobs.pycurv_tab import PyCurvWidget
+        w = PyCurvWidget(MagicMock())
+        assert w.radius_hit_input.max >= 90
+        w.radius_hit_input.value = 90
+        assert w.radius_hit_input.value == 90
+
+    @pytest.mark.gui
+    def test_extrapolation_distance_accepts_angstrom_scale(self, qapp, mock_experiment_manager):
+        from jobs.mesh_tab import MeshGenerationWidget
+        w = MeshGenerationWidget(mock_experiment_manager)
+        assert w.extrapolation_distance.max >= 15
+        w.extrapolation_distance.value = 15
+        assert w.extrapolation_distance.value == 15
+
+    @pytest.mark.gui
+    def test_distance_widgets_accept_angstrom_scale(self, qapp):
+        from jobs.distance_tab import DistanceOrientationWidget
+        w = DistanceOrientationWidget(MagicMock())
+        assert w.min_dist.max >= 4000 and w.max_dist.max >= 4000
+        w.max_dist.value = 4000
+        assert w.max_dist.value == 4000


### PR DESCRIPTION
Follow-up to #42.

The ARM64 SIGBUS fix from #42 works, but the `StatusChecker` monkeypatch in `main.py` had two fragilities that this PR addresses:

- **Wrap the private-API import in `try/except ImportError`.** It patches `napari._qt.threads.status_checker` at import time, so a future napari version that moves or renames that class would `ImportError` and break GUI startup for *everyone*. Now it degrades to a logged warning instead.
- **Gate the patch to macOS.** The trigger is the small ~512 KB default `QThread` stack, which is a macOS trait (Intel and Apple Silicon alike). Linux and Windows hand out much larger defaults and never hit this, so there's no reason to monkeypatch napari internals there.

Also adds regression tests in `tests/test_known_bugs.py` for two of #42's fixes so they don't silently regress:
- the relative-import fix in `_import_cli_project`
- the angstrom-scale widget range bumps (`radius_hit`, `extrapolation_distance`, `min`/`max_dist`)

All tests pass (`pytest tests/`, 93 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)