### PR TITLE
feat: density-guided mesh refinement tab (+ thickness tab, distance archive fix)

### DIFF
--- a/src/surface_morphometrics_gui/jobs/distance_tab.py
+++ b/src/surface_morphometrics_gui/jobs/distance_tab.py
@@ -302,7 +302,14 @@ class DistanceOrientationWidget(QWidget):
              archive_config_path = exp_dir / f"{exp_name}_config.yml"
              archive_dir = resolve_work_dir(exp_dir)
 
-             if not check_and_archive_outputs(self.native, archive_dir, config_path=archive_config_path, file_patterns=['*.csv', '*.svg', '*.png'], exclude_patterns=['*AVV*', '*VV*', '*.gt', '*_runtimes.csv']):
+             # Excludes cover pycurv outputs (AVV/VV/.gt) and mesh-refinement
+             # artifacts, which live in the same results/ dir but are not
+             # distance-measurement outputs.
+             refinement_excludes = [
+                 '*_refinement_*', '*_profile_evolution*',
+                 '*_profile_iter*', '*_samples_iter*', '*lightweight*',
+             ]
+             if not check_and_archive_outputs(self.native, archive_dir, config_path=archive_config_path, file_patterns=['*.csv', '*.svg', '*.png'], exclude_patterns=['*AVV*', '*VV*', '*.gt', '*_runtimes.csv'] + refinement_excludes):
                  return
         except Exception as e:
              print(f"Archive check failed: {e}")

--- a/src/surface_morphometrics_gui/jobs/refinement_tab.py
+++ b/src/surface_morphometrics_gui/jobs/refinement_tab.py
@@ -1,0 +1,454 @@
+import copy
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+from magicgui import widgets
+from qtpy.QtCore import QTimer
+from ruamel.yaml import YAML
+from qtpy.QtWidgets import (
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..utils.archive_utils import check_and_archive_outputs
+from ..utils.script_resolver import (
+    resolve_cli_runner,
+    CLI_MISSING_MESSAGE,
+    REFINE_MESH,
+    ACCEPT_REFINEMENT,
+    resolve_work_dir,
+    cli_work_dir,
+)
+from ..widgets.job_status import JobStatusWidget
+
+# Refinement-only outputs. Archived before a re-run and never touch the
+# canonical *.surface.vtp / *.AVV_rh*.gt graphs that pycurv produced.
+REFINE_OUTPUT_PATTERNS = [
+    '*_refined_iter*',
+    '*_profile_iter*.png',
+    '*_samples_iter*.png',
+    '*_refinement_convergence.png',
+    '*_refinement_stats.csv',
+    '*_profile_evolution.png',
+]
+
+
+class RefinementWidget(QWidget):
+    """Optional density-guided mesh refinement tab.
+
+    Refinement is the optional step between curvature (pycurv) and distances.
+    It nudges surface vertices toward the true membrane center using the
+    tomogram density, in two CLI actions driven from this tab:
+
+    1. ``morphometrics refine_mesh`` iterates over the pycurv ``.gt`` graphs in
+       the work dir, sampling density from the tomograms in ``tomo_dir`` and
+       writing ``*_refined_iter{N}.*`` surfaces plus convergence/profile plots.
+       The user inspects those plots to choose the best iteration.
+    2. ``morphometrics accept_refinement <step>`` promotes the chosen iteration
+       to be the canonical surface (backing up the original) and removes the
+       other refinement intermediates.
+
+    Like thickness, refinement needs a ``tomo_dir`` (not held by the shared
+    ExperimentManager) and the existing pycurv graphs, so this tab validates
+    both before running.
+    """
+
+    def __init__(self, experiment_manager):
+        super().__init__()
+        self.experiment_manager = experiment_manager
+        self.is_running = False
+
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(5, 5, 5, 5)
+        self.setLayout(main_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        inner = QWidget()
+        inner_layout = QVBoxLayout()
+        inner_layout.setContentsMargins(0, 0, 0, 0)
+        inner.setLayout(inner_layout)
+        scroll.setWidget(inner)
+        main_layout.addWidget(scroll)
+
+        inner_layout.addWidget(QLabel("<b>Density-Guided Mesh Refinement</b>"))
+        inner_layout.addWidget(QLabel(
+            "Optional. Run after curvature, before distances. Refine, inspect the\n"
+            "convergence plots in the work dir, then accept the best iteration."))
+
+        # --- Tomogram directory (not held by ExperimentManager) ---
+        inner_layout.addWidget(QLabel("Tomogram Directory (raw MRCs for density sampling):"))
+        self.tomo_dir_input = widgets.FileEdit(mode='d', label='Tomogram Dir')
+        inner_layout.addWidget(self.tomo_dir_input.native)
+
+        # --- Refinement settings ---
+        settings = widgets.Container(layout='vertical', labels=True)
+        settings.native.layout().setSpacing(5)
+        settings.native.layout().setContentsMargins(3, 3, 3, 3)
+        self.iterations_input = widgets.SpinBox(
+            value=6, min=1, max=50, label='Iterations')
+        self.iterations_input.tooltip = "Number of refinement iterations."
+        self.damping_input = widgets.FloatSpinBox(
+            value=0.9, min=0.0, max=1.0, step=0.05, label='Damping Factor')
+        self.damping_input.tooltip = "Fraction of the computed impulse applied per iteration. Lower prevents oscillation."
+        self.average_radius_input = widgets.FloatSpinBox(
+            value=25.0, min=1.0, max=100.0, step=1.0, label='Average Radius (nm)')
+        self.average_radius_input.tooltip = "Radius for local averaging of density profiles. Larger = more smoothing."
+        self.max_offset_input = widgets.FloatSpinBox(
+            value=8.0, min=0.5, max=50.0, step=0.5, label='Max Total Offset (nm)')
+        self.max_offset_input.tooltip = "Maximum total displacement from the original surface. Prevents divergence."
+        self.xcorr_iterations_input = widgets.SpinBox(
+            value=3, min=0, max=50, label='Initial XCorr Iterations')
+        self.xcorr_iterations_input.tooltip = (
+            "Number of initial iterations using cross-correlation to sharpen the bilayer "
+            "before switching to dual-Gaussian fitting. 0 = Gaussian fitting throughout.")
+        self.monolayer_input = widgets.CheckBox(value=False, label='Monolayer (single Gaussian)')
+        self.monolayer_input.tooltip = "For high-defocus data where the bilayer is not resolved."
+        self.smooth_offsets_input = widgets.CheckBox(value=True, label='Smooth Offset Field')
+        self.smooth_offsets_input.tooltip = "Spatially smooth the offset field before applying it. Reduces local noise."
+        self.laplacian_input = widgets.SpinBox(
+            value=5, min=0, max=20, label='Laplacian Iterations')
+        self.laplacian_input.tooltip = "Laplacian smoothing iterations after displacement (0 = disabled)."
+        self.laplacian_lambda_input = widgets.FloatSpinBox(
+            value=0.5, min=0.0, max=1.0, step=0.05, label='Laplacian Lambda')
+        self.laplacian_lambda_input.tooltip = "Laplacian smoothing strength. Higher = more smoothing but may lose detail."
+        self.lowpass_input = widgets.FloatSpinBox(
+            value=0.0, min=0.0, max=10.0, step=0.5, label='Low-pass Sigma (nm)')
+        self.lowpass_input.tooltip = "3D Gaussian low-pass on the tomogram before sampling. 0 = disabled; try 1-3 nm for noisy data."
+        settings.extend([
+            self.iterations_input,
+            self.damping_input,
+            self.average_radius_input,
+            self.max_offset_input,
+            self.xcorr_iterations_input,
+            self.monolayer_input,
+            self.smooth_offsets_input,
+            self.laplacian_input,
+            self.laplacian_lambda_input,
+            self.lowpass_input,
+        ])
+        inner_layout.addWidget(QLabel("<b>Settings</b>"))
+        inner_layout.addWidget(settings.native)
+
+        # --- Run refinement + status ---
+        self.submit_btn = widgets.PushButton(text='Run Refinement')
+        self.submit_btn.clicked.connect(self._run_refinement)
+        inner_layout.addWidget(self.submit_btn.native)
+
+        # --- Accept an iteration (destructive: promotes one, removes the rest) ---
+        inner_layout.addWidget(QLabel("<b>Accept Iteration</b>"))
+        inner_layout.addWidget(QLabel(
+            "Promote one iteration to be the working surface (originals are backed\n"
+            "up). Inspect *_refinement_convergence.png first to pick the best one."))
+        accept = widgets.Container(layout='vertical', labels=True)
+        accept.native.layout().setSpacing(5)
+        accept.native.layout().setContentsMargins(3, 3, 3, 3)
+        self.accept_step_input = widgets.SpinBox(
+            value=1, min=1, max=50, label='Iteration to Accept')
+        accept.extend([self.accept_step_input])
+        inner_layout.addWidget(accept.native)
+        self.accept_btn = QPushButton('Accept Iteration')
+        self.accept_btn.clicked.connect(self._accept_iteration)
+        inner_layout.addWidget(self.accept_btn)
+
+        self.status = JobStatusWidget()
+        inner_layout.addWidget(self.status.native)
+        inner_layout.addStretch(1)
+
+        if hasattr(self.experiment_manager, 'config_loaded'):
+            self.experiment_manager.config_loaded.connect(self._on_config_loaded)
+            if self.experiment_manager.current_config:
+                self._on_config_loaded()
+
+    def _on_config_loaded(self):
+        try:
+            self.status.update_status('Ready')
+            self.status.update_progress(0)
+            config = self.experiment_manager.current_config or {}
+            if config.get('tomo_dir'):
+                self.tomo_dir_input.value = config['tomo_dir']
+            refine = config.get('mesh_refinement', {}) or {}
+            self.iterations_input.value = refine.get('iterations', 6)
+            self.damping_input.value = refine.get('damping_factor', 0.9)
+            density = config.get('density_sampling', config.get('thickness_measurements', {}))
+            self.average_radius_input.value = refine.get(
+                'average_radius', density.get('average_radius', 25))
+            self.max_offset_input.value = refine.get('max_total_offset', 8)
+            xcorr = refine.get('xcorr_iterations', 3)
+            # Config may carry a list of iteration numbers; the GUI exposes the
+            # "first N" form, so collapse a contiguous-from-1 list to its length.
+            self.xcorr_iterations_input.value = (
+                len(xcorr) if isinstance(xcorr, (list, tuple)) else (xcorr or 0))
+            self.monolayer_input.value = refine.get('monolayer', False)
+            self.smooth_offsets_input.value = refine.get('smooth_offsets', True)
+            self.laplacian_input.value = refine.get('laplacian_iterations', 5)
+            self.laplacian_lambda_input.value = refine.get('laplacian_lambda', 0.5)
+            self.lowpass_input.value = refine.get('lowpass_sigma', 0)
+        except Exception as e:
+            print(f"[RefinementWidget] Error in _on_config_loaded: {e}")
+
+    def _config_path(self):
+        exp_name = self.experiment_manager.experiment_name.currentText()
+        exp_dir = Path(self.experiment_manager.work_dir.value) / exp_name
+        preferred = exp_dir / f"{exp_name}_config.yml"
+        fallback = exp_dir / 'config.yml'
+        return (preferred if preferred.exists() else fallback), exp_dir
+
+    def _radius_hit(self):
+        config = self.experiment_manager.current_config or {}
+        return config.get('curvature_measurements', {}).get('radius_hit', 9)
+
+    def _update_config(self):
+        """Write tomo_dir, work_dir and the mesh_refinement block into config.yml."""
+        if not self.experiment_manager.current_config:
+            raise ValueError("Experiment configuration not loaded.")
+
+        config_path, exp_dir = self._config_path()
+
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        existing = {}
+        if config_path.exists():
+            try:
+                with open(config_path, 'r') as f:
+                    existing = yaml.load(f) or {}
+            except Exception:
+                existing = {}
+        else:
+            existing = copy.deepcopy(self.experiment_manager.current_config)
+
+        # Every step shares one output dir; the CLI concatenates work_dir +
+        # basename, so it must end in a separator.
+        out_dir = resolve_work_dir(exp_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        existing['work_dir'] = cli_work_dir(out_dir)
+        existing['cores'] = self.experiment_manager.cores_input.value()
+
+        tomo_dir = str(self.tomo_dir_input.value)
+        existing['tomo_dir'] = tomo_dir + os.sep if not tomo_dir.endswith(os.sep) else tomo_dir
+
+        existing.setdefault('mesh_refinement', {})
+        existing['mesh_refinement'].update({
+            'iterations': self.iterations_input.value,
+            'damping_factor': self.damping_input.value,
+            'average_radius': self.average_radius_input.value,
+            'max_total_offset': self.max_offset_input.value,
+            # Config accepts "first N iterations" as an int.
+            'xcorr_iterations': self.xcorr_iterations_input.value,
+            'monolayer': self.monolayer_input.value,
+            'smooth_offsets': self.smooth_offsets_input.value,
+            'laplacian_iterations': self.laplacian_input.value,
+            'laplacian_lambda': self.laplacian_lambda_input.value,
+            'lowpass_sigma': self.lowpass_input.value,
+        })
+
+        with open(config_path, 'w') as f:
+            yaml.dump(existing, f)
+
+        return config_path
+
+    # ----- Run refinement -----
+
+    def _run_refinement(self):
+        if self.is_running:
+            return
+
+        tomo_dir = str(self.tomo_dir_input.value or '')
+        if not tomo_dir or not Path(tomo_dir).is_dir():
+            QMessageBox.warning(self, "No Tomogram Directory",
+                                "Select the directory containing the raw tomogram MRC files.")
+            return
+        if not list(Path(tomo_dir).glob('*.mrc')):
+            QMessageBox.warning(self, "No Tomograms", f"No .mrc files found in {tomo_dir}.")
+            return
+
+        config_path, exp_dir = self._config_path()
+        work_dir = resolve_work_dir(exp_dir)
+        radius_hit = self._radius_hit()
+        if not list(work_dir.glob(f'*.AVV_rh{radius_hit}.gt')):
+            QMessageBox.warning(
+                self, "No Curvature Graphs",
+                f"No pycurv graphs (*.AVV_rh{radius_hit}.gt) found in {work_dir}.\n"
+                "Run the Curvature step before refining the mesh.")
+            return
+
+        try:
+            config_path = self._update_config()
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to update config: {e}")
+            return
+
+        runner = resolve_cli_runner()
+        if runner is None:
+            QMessageBox.critical(self, "morphometrics CLI not found", CLI_MISSING_MESSAGE)
+            print(f"[Error] {CLI_MISSING_MESSAGE}")
+            return
+
+        # Archive prior refinement outputs only; never touch the canonical
+        # pycurv graphs/surfaces that refinement reads from.
+        try:
+            if not check_and_archive_outputs(
+                self, work_dir, config_path=config_path,
+                file_patterns=REFINE_OUTPUT_PATTERNS,
+            ):
+                print("User cancelled.")
+                return
+        except Exception as e:
+            print(f"Archive check failed: {e}")
+
+        job_data = {
+            'runner': runner,
+            'config_path': config_path,
+            'iterations': self.iterations_input.value,
+        }
+        self.is_running = True
+        self.submit_btn.enabled = False
+        self.accept_btn.setEnabled(False)
+        self.status.update_status('Starting...')
+        self.status.update_progress(0)
+        threading.Thread(target=self._run_refinement_worker, args=(job_data,), daemon=True).start()
+
+    def _run_refinement_worker(self, job_data):
+        try:
+            runner = job_data['runner']
+            config_path = job_data['config_path']
+            iterations = max(1, job_data['iterations'])
+            work_dir = resolve_work_dir(Path(config_path).parent).resolve()
+
+            cmd = runner + [REFINE_MESH, str(config_path)]
+            print(f"--- Refining mesh: {' '.join(map(str, cmd))} ---")
+            self.status.update_status('Refining mesh...')
+            self.status.update_progress(5)
+
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            process = subprocess.Popen(
+                cmd, cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, bufsize=1, universal_newlines=True, env=env,
+            )
+            if process.stdout is not None:
+                for line in process.stdout:
+                    line = line.rstrip()
+                    if not line:
+                        continue
+                    print(line)
+                    # refine_mesh prints "=== Iteration N/M ===" per iteration.
+                    if "=== Iteration" in line:
+                        try:
+                            n = int(line.split("Iteration", 1)[1].split("/", 1)[0])
+                            self.status.update_status(f'Iteration {n}/{iterations}...')
+                            self.status.update_progress(min(95, int(95 * n / iterations)))
+                        except (ValueError, IndexError):
+                            pass
+            return_code = process.wait()
+
+            if return_code != 0:
+                self.status.update_status('Error: refinement failed. See terminal.')
+                print("[ERROR] refine_mesh failed. Check the terminal output.")
+                return
+
+            if not list(work_dir.glob('*_refined_iter*.surface.vtp')):
+                self.status.update_status('Error: no refined surfaces produced.')
+                print("[ERROR] refine_mesh produced no *_refined_iter*.surface.vtp. "
+                      "Check that pycurv graphs (.gt) and tomogram basenames match.")
+                return
+
+            self.status.update_progress(100)
+            self.status.update_status(
+                'Refinement complete. Inspect *_refinement_convergence.png, then accept an iteration.')
+            print("===== Mesh refinement complete. =====")
+
+        except Exception as e:
+            self.status.update_status(f'Error: {e}')
+            print(f"A critical error occurred in the refinement worker: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            QTimer.singleShot(0, self._job_cleanup)
+
+    # ----- Accept an iteration -----
+
+    def _accept_iteration(self):
+        if self.is_running:
+            return
+
+        if not self.experiment_manager.current_config:
+            QMessageBox.warning(self, "No Experiment", "Load an experiment first.")
+            return
+
+        config_path, exp_dir = self._config_path()
+        if not config_path.exists():
+            QMessageBox.warning(self, "No Config", f"Config not found: {config_path}")
+            return
+
+        step = self.accept_step_input.value
+        work_dir = resolve_work_dir(exp_dir)
+        if not list(work_dir.glob(f'*_refined_iter{step}.surface.vtp')):
+            QMessageBox.warning(
+                self, "No Such Iteration",
+                f"No refined surfaces for iteration {step} found in {work_dir}.\n"
+                "Run refinement first, or pick an iteration that was produced.")
+            return
+
+        confirm = QMessageBox.question(
+            self, "Accept Iteration",
+            f"Promote iteration {step} to be the working surface?\n\n"
+            "The original surfaces are backed up (*.orig.bak), but the other "
+            "refinement iterations and intermediates will be removed. This cannot "
+            "be undone from the GUI.",
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if confirm != QMessageBox.Yes:
+            return
+
+        runner = resolve_cli_runner()
+        if runner is None:
+            QMessageBox.critical(self, "morphometrics CLI not found", CLI_MISSING_MESSAGE)
+            return
+
+        job_data = {'runner': runner, 'config_path': config_path, 'step': step}
+        self.is_running = True
+        self.submit_btn.enabled = False
+        self.accept_btn.setEnabled(False)
+        self.status.update_status(f'Accepting iteration {step}...')
+        threading.Thread(target=self._accept_worker, args=(job_data,), daemon=True).start()
+
+    def _accept_worker(self, job_data):
+        try:
+            runner = job_data['runner']
+            config_path = job_data['config_path']
+            step = job_data['step']
+            work_dir = resolve_work_dir(Path(config_path).parent).resolve()
+
+            cmd = runner + [ACCEPT_REFINEMENT, str(config_path), str(step)]
+            print(f"--- Accepting refinement: {' '.join(map(str, cmd))} ---")
+            try:
+                subprocess.run(cmd, cwd=work_dir, check=True, text=True)
+            except subprocess.CalledProcessError:
+                self.status.update_status('Error: accept_refinement failed. See terminal.')
+                print("[ERROR] accept_refinement failed. Check the terminal output.")
+                return
+
+            self.status.update_status(
+                f'Accepted iteration {step}. If it was a lightweight (xcorr) iteration, '
+                're-run Curvature before distances.')
+            print(f"===== Accepted refinement iteration {step}. =====")
+
+        except Exception as e:
+            self.status.update_status(f'Error: {e}')
+            print(f"A critical error occurred while accepting refinement: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            QTimer.singleShot(0, self._job_cleanup)
+
+    def _job_cleanup(self):
+        self.submit_btn.enabled = True
+        self.accept_btn.setEnabled(True)
+        self.is_running = False

--- a/src/surface_morphometrics_gui/jobs/thickness_tab.py
+++ b/src/surface_morphometrics_gui/jobs/thickness_tab.py
@@ -1,0 +1,336 @@
+import copy
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+from magicgui import widgets
+from qtpy.QtCore import QTimer
+from ruamel.yaml import YAML
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..utils.archive_utils import check_and_archive_outputs
+from ..utils.script_resolver import (
+    resolve_cli_runner,
+    CLI_MISSING_MESSAGE,
+    SAMPLE_DENSITY,
+    MEASURE_THICKNESS,
+    resolve_work_dir,
+    cli_work_dir,
+)
+from ..widgets.job_status import JobStatusWidget
+
+
+class ThicknessWidget(QWidget):
+    """Membrane thickness measurement tab.
+
+    Thickness is a two-step CLI flow run sequentially from one button:
+
+    1. ``morphometrics sample_density`` samples tomogram density along surface
+       normals, reading the pycurv ``.gt`` graphs in the work dir and the
+       tomograms in ``tomo_dir``, writing ``*_sampling.csv`` per surface.
+    2. ``morphometrics measure_thickness`` fits a dual Gaussian to each profile
+       and writes ``component_list.csv`` plus per-surface plots.
+
+    The shared ExperimentManager has no ``tomo_dir`` field, so this tab captures
+    it (sample_density requires it) and writes it into the experiment config.
+    """
+
+    def __init__(self, experiment_manager):
+        super().__init__()
+        self.experiment_manager = experiment_manager
+        self.component_checkboxes = []
+        self.is_running = False
+
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(5, 5, 5, 5)
+        self.setLayout(main_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        inner = QWidget()
+        inner_layout = QVBoxLayout()
+        inner_layout.setContentsMargins(0, 0, 0, 0)
+        inner.setLayout(inner_layout)
+        scroll.setWidget(inner)
+        main_layout.addWidget(scroll)
+
+        inner_layout.addWidget(QLabel("<b>Membrane Thickness Measurement</b>"))
+
+        # --- Tomogram directory (not held by ExperimentManager) ---
+        inner_layout.addWidget(QLabel("Tomogram Directory (raw MRCs for density sampling):"))
+        self.tomo_dir_input = widgets.FileEdit(mode='d', label='Tomogram Dir')
+        inner_layout.addWidget(self.tomo_dir_input.native)
+
+        # --- Sampling + fitting settings ---
+        settings = widgets.Container(layout='vertical', labels=True)
+        settings.native.layout().setSpacing(5)
+        settings.native.layout().setContentsMargins(3, 3, 3, 3)
+        self.sample_spacing_input = widgets.FloatSpinBox(
+            value=0.25, min=0.01, max=10.0, step=0.05, label='Sample Spacing (nm)')
+        self.sample_spacing_input.tooltip = "Distance between samples along the normal. Should divide evenly into scan range."
+        self.scan_range_input = widgets.FloatSpinBox(
+            value=10.0, min=1.0, max=100.0, step=1.0, label='Scan Range (nm)')
+        self.scan_range_input.tooltip = "Half-range scanned along the normal (-range to +range)."
+        self.average_radius_input = widgets.FloatSpinBox(
+            value=12.0, min=1.0, max=100.0, step=1.0, label='Average Radius (nm)')
+        self.average_radius_input.tooltip = "Radius for local averaging of density profiles in the fit."
+        self.fit_curve_input = widgets.CheckBox(value=True, label='Fit Dual Gaussian')
+        settings.extend([
+            self.sample_spacing_input,
+            self.scan_range_input,
+            self.average_radius_input,
+            self.fit_curve_input,
+        ])
+        inner_layout.addWidget(QLabel("<b>Settings</b>"))
+        inner_layout.addWidget(settings.native)
+
+        # --- Components to process (from segmentation_values) ---
+        inner_layout.addWidget(QLabel("<b>Components to Measure:</b>"))
+        self.refresh_btn = QPushButton('Refresh Components')
+        self.refresh_btn.clicked.connect(self._populate_components)
+        inner_layout.addWidget(self.refresh_btn)
+        self.components_container = QWidget()
+        self.components_layout = QVBoxLayout()
+        self.components_layout.setContentsMargins(0, 0, 0, 0)
+        self.components_container.setLayout(self.components_layout)
+        inner_layout.addWidget(self.components_container)
+
+        # --- Run + status ---
+        self.submit_btn = widgets.PushButton(text='Run Thickness Analysis')
+        self.submit_btn.clicked.connect(self._run_job)
+        self.status = JobStatusWidget()
+        inner_layout.addWidget(self.submit_btn.native)
+        inner_layout.addWidget(self.status.native)
+        inner_layout.addStretch(1)
+
+        if hasattr(self.experiment_manager, 'config_loaded'):
+            self.experiment_manager.config_loaded.connect(self._on_config_loaded)
+            if self.experiment_manager.current_config:
+                self._on_config_loaded()
+
+    def _segmentation_components(self):
+        """Component names available to measure, taken from segmentation_values."""
+        config = self.experiment_manager.current_config or {}
+        seg = config.get('segmentation_values', {}) or {}
+        return list(seg.keys())
+
+    def _populate_components(self):
+        for i in reversed(range(self.components_layout.count())):
+            w = self.components_layout.itemAt(i).widget()
+            if w is not None:
+                w.setParent(None)
+        self.component_checkboxes.clear()
+
+        names = self._segmentation_components()
+        if not names:
+            self.components_layout.addWidget(
+                QLabel("No segmentation labels found. Configure the experiment first."))
+            return
+
+        # Pre-check whatever the saved config already targets for thickness;
+        # default to all components when nothing is saved yet.
+        config = self.experiment_manager.current_config or {}
+        saved = config.get('thickness_measurements', {}).get('components')
+        preselect = set(saved) if saved else set(names)
+
+        for name in names:
+            cb = QCheckBox(name)
+            cb.setChecked(name in preselect)
+            self.component_checkboxes.append(cb)
+            self.components_layout.addWidget(cb)
+
+    def _selected_components(self):
+        return [cb.text() for cb in self.component_checkboxes if cb.isChecked()]
+
+    def _on_config_loaded(self):
+        try:
+            self.status.update_status('Ready')
+            self.status.update_progress(0)
+            self._populate_components()
+            config = self.experiment_manager.current_config or {}
+            if config.get('tomo_dir'):
+                self.tomo_dir_input.value = config['tomo_dir']
+            density = config.get('density_sampling',
+                                 config.get('thickness_measurements', {}))
+            self.sample_spacing_input.value = density.get('sample_spacing', 0.25)
+            self.scan_range_input.value = density.get('scan_range', 10)
+            thickness = config.get('thickness_measurements', {})
+            self.average_radius_input.value = thickness.get('average_radius', 12)
+            self.fit_curve_input.value = thickness.get('fit_curve', True)
+        except Exception as e:
+            print(f"[ThicknessWidget] Error in _on_config_loaded: {e}")
+
+    def _update_config(self, components):
+        """Write current widget values into the experiment config.yml."""
+        if not self.experiment_manager.current_config:
+            raise ValueError("Experiment configuration not loaded.")
+
+        exp_name = self.experiment_manager.experiment_name.currentText()
+        exp_dir = Path(self.experiment_manager.work_dir.value) / exp_name
+        preferred_config_path = exp_dir / f"{exp_name}_config.yml"
+        fallback_config_path = exp_dir / 'config.yml'
+        config_path = preferred_config_path if preferred_config_path.exists() else fallback_config_path
+
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        existing = {}
+        if config_path.exists():
+            try:
+                with open(config_path, 'r') as f:
+                    existing = yaml.load(f) or {}
+            except Exception:
+                existing = {}
+        else:
+            config_path = preferred_config_path
+            existing = copy.deepcopy(self.experiment_manager.current_config)
+
+        # Every step shares one output dir; the CLI concatenates work_dir +
+        # basename, so it must end in a separator.
+        out_dir = resolve_work_dir(exp_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        existing['work_dir'] = cli_work_dir(out_dir)
+        existing['cores'] = self.experiment_manager.cores_input.value()
+
+        # sample_density globs tomo_dir for *.mrc; the CLI appends a separator
+        # itself but we normalize here so the saved config is unambiguous.
+        tomo_dir = str(self.tomo_dir_input.value)
+        existing['tomo_dir'] = tomo_dir + os.sep if not tomo_dir.endswith(os.sep) else tomo_dir
+
+        existing.setdefault('density_sampling', {})
+        existing['density_sampling'].update({
+            'sample_spacing': self.sample_spacing_input.value,
+            'scan_range': self.scan_range_input.value,
+        })
+
+        existing.setdefault('thickness_measurements', {})
+        existing['thickness_measurements'].update({
+            'average_radius': self.average_radius_input.value,
+            'fit_curve': self.fit_curve_input.value,
+            'components': components,
+        })
+
+        with open(config_path, 'w') as f:
+            yaml.dump(existing, f)
+
+        return config_path
+
+    def _run_job(self):
+        if self.is_running:
+            return
+
+        components = self._selected_components()
+        if not components:
+            QMessageBox.warning(self, "No Components", "Select at least one component to measure.")
+            return
+
+        tomo_dir = str(self.tomo_dir_input.value or '')
+        if not tomo_dir or not Path(tomo_dir).is_dir():
+            QMessageBox.warning(self, "No Tomogram Directory",
+                                "Select the directory containing the raw tomogram MRC files.")
+            return
+        if not list(Path(tomo_dir).glob('*.mrc')):
+            QMessageBox.warning(self, "No Tomograms",
+                                f"No .mrc files found in {tomo_dir}.")
+            return
+
+        try:
+            config_path = self._update_config(components)
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to update config: {e}")
+            return
+
+        runner = resolve_cli_runner()
+        if runner is None:
+            QMessageBox.critical(self, "morphometrics CLI not found", CLI_MISSING_MESSAGE)
+            print(f"[Error] {CLI_MISSING_MESSAGE}")
+            return
+
+        # Thickness outputs only; never touch the pycurv graphs/curvature CSVs.
+        try:
+            exp_name = self.experiment_manager.experiment_name.currentText()
+            exp_dir = Path(self.experiment_manager.work_dir.value) / exp_name
+            archive_dir = resolve_work_dir(exp_dir)
+            if not check_and_archive_outputs(
+                self, archive_dir, config_path=config_path,
+                file_patterns=['*_sampling.csv', 'component_list.csv', '*_thickness*.svg', '*_thickness*.png'],
+            ):
+                print("User cancelled.")
+                return
+        except Exception as e:
+            print(f"Archive check failed: {e}")
+
+        job_data = {'runner': runner, 'config_path': config_path}
+        self.is_running = True
+        self.submit_btn.enabled = False
+        self.status.update_status('Starting...')
+        self.status.update_progress(0)
+        threading.Thread(target=self._run_job_worker, args=(job_data,), daemon=True).start()
+
+    def _run_job_worker(self, job_data):
+        try:
+            runner = job_data['runner']
+            config_path = job_data['config_path']
+            work_dir = resolve_work_dir(Path(config_path).parent).resolve()
+
+            # Step 1: sample density (processes every tomogram in tomo_dir).
+            self.status.update_status('Step 1/2: Sampling tomogram density...')
+            self.status.update_progress(10)
+            cmd = runner + [SAMPLE_DENSITY, str(config_path)]
+            print(f"--- Sampling density: {' '.join(cmd)} ---")
+            try:
+                subprocess.run(cmd, cwd=work_dir, check=True, text=True)
+            except subprocess.CalledProcessError:
+                self.status.update_status('Error: density sampling failed. See terminal.')
+                print("[ERROR] sample_density failed. Check the terminal output.")
+                return
+
+            # sample_density catches per-surface errors and still exits 0, so
+            # confirm sampling CSVs were actually written before fitting.
+            if not list(work_dir.glob('*_sampling.csv')):
+                self.status.update_status('Error: no sampling output produced.')
+                print("[ERROR] sample_density produced no *_sampling.csv. "
+                      "Check that pycurv graphs (.gt) and tomogram basenames match.")
+                return
+
+            # Step 2: fit thickness.
+            self.status.update_status('Step 2/2: Measuring thickness...')
+            self.status.update_progress(60)
+            cmd = runner + [MEASURE_THICKNESS, str(config_path)]
+            print(f"--- Measuring thickness: {' '.join(cmd)} ---")
+            try:
+                subprocess.run(cmd, cwd=work_dir, check=True, text=True)
+            except subprocess.CalledProcessError:
+                self.status.update_status('Error: thickness measurement failed. See terminal.')
+                print("[ERROR] measure_thickness failed. Check the terminal output.")
+                return
+
+            if not (work_dir / 'component_list.csv').exists():
+                self.status.update_status('Error: no thickness output produced.')
+                print("[ERROR] measure_thickness produced no component_list.csv.")
+                return
+
+            self.status.update_progress(100)
+            self.status.update_status('Completed. See component_list.csv and plots in the work dir.')
+            print("===== Thickness analysis complete. =====")
+
+        except Exception as e:
+            self.status.update_status(f'Error: {e}')
+            print(f"A critical error occurred in the thickness worker: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            QTimer.singleShot(0, self._job_cleanup)
+
+    def _job_cleanup(self):
+        self.submit_btn.enabled = True
+        self.is_running = False

--- a/src/surface_morphometrics_gui/main.py
+++ b/src/surface_morphometrics_gui/main.py
@@ -36,6 +36,7 @@ _patch_status_checker_stack_size()
 from .jobs.mesh_tab import MeshGenerationWidget
 from .jobs.pycurv_tab import PyCurvWidget
 from .jobs.distance_tab import DistanceOrientationWidget
+from .jobs.thickness_tab import ThicknessWidget
 from .plugins.tomoslice_plugin import TomoslicePlugin
 from .plugins.mesh_viewer import MeshViewer
 from .plugins.protein import ProteinLoaderPlugin
@@ -69,6 +70,7 @@ def main():
         mesh_widget = MeshGenerationWidget(experiment_manager)
         pycurv_widget = PyCurvWidget(experiment_manager=experiment_manager)
         distance_widget = DistanceOrientationWidget(experiment_manager)
+        thickness_widget = ThicknessWidget(experiment_manager)
 
         # (Mesh completion connection set after dock widgets are created below)
         # Create tomoslice plugin
@@ -84,6 +86,7 @@ def main():
         dw2 = viewer.window.add_dock_widget(mesh_widget, name='Surface Mesh', area='right')
         dw3 = viewer.window.add_dock_widget(pycurv_widget, name='Curvature', area='right')
         dw4 = viewer.window.add_dock_widget(distance_widget.native, name='Distance', area='right')
+        dw5 = viewer.window.add_dock_widget(thickness_widget, name='Thickness', area='right')
 
         # Add Mesh Viewer to the right side, tabified with the other widgets
         dw_mesh = viewer.window.add_dock_widget(
@@ -99,7 +102,8 @@ def main():
         viewer.window._qt_window.tabifyDockWidget(dw1, dw2)
         viewer.window._qt_window.tabifyDockWidget(dw2, dw3)
         viewer.window._qt_window.tabifyDockWidget(dw3, dw4)
-        viewer.window._qt_window.tabifyDockWidget(dw4, dw_mesh)
+        viewer.window._qt_window.tabifyDockWidget(dw4, dw5)
+        viewer.window._qt_window.tabifyDockWidget(dw5, dw_mesh)
         viewer.window._qt_window.tabifyDockWidget(dw_mesh, dw_protein_loader)
         
         # Connect mesh generation completion signal to PyCurv file list refresh

--- a/src/surface_morphometrics_gui/main.py
+++ b/src/surface_morphometrics_gui/main.py
@@ -35,6 +35,7 @@ _patch_status_checker_stack_size()
 
 from .jobs.mesh_tab import MeshGenerationWidget
 from .jobs.pycurv_tab import PyCurvWidget
+from .jobs.refinement_tab import RefinementWidget
 from .jobs.distance_tab import DistanceOrientationWidget
 from .jobs.thickness_tab import ThicknessWidget
 from .plugins.tomoslice_plugin import TomoslicePlugin
@@ -69,6 +70,7 @@ def main():
         experiment_manager = ExperimentManager(viewer)
         mesh_widget = MeshGenerationWidget(experiment_manager)
         pycurv_widget = PyCurvWidget(experiment_manager=experiment_manager)
+        refinement_widget = RefinementWidget(experiment_manager)
         distance_widget = DistanceOrientationWidget(experiment_manager)
         thickness_widget = ThicknessWidget(experiment_manager)
 
@@ -85,6 +87,7 @@ def main():
         dw1 = viewer.window.add_dock_widget(experiment_manager, name='Experiment Manager', area='right')
         dw2 = viewer.window.add_dock_widget(mesh_widget, name='Surface Mesh', area='right')
         dw3 = viewer.window.add_dock_widget(pycurv_widget, name='Curvature', area='right')
+        dw_refine = viewer.window.add_dock_widget(refinement_widget, name='Mesh Refinement', area='right')
         dw4 = viewer.window.add_dock_widget(distance_widget.native, name='Distance', area='right')
         dw5 = viewer.window.add_dock_widget(thickness_widget, name='Thickness', area='right')
 
@@ -101,7 +104,8 @@ def main():
         # Tabify all right-side dock widgets
         viewer.window._qt_window.tabifyDockWidget(dw1, dw2)
         viewer.window._qt_window.tabifyDockWidget(dw2, dw3)
-        viewer.window._qt_window.tabifyDockWidget(dw3, dw4)
+        viewer.window._qt_window.tabifyDockWidget(dw3, dw_refine)
+        viewer.window._qt_window.tabifyDockWidget(dw_refine, dw4)
         viewer.window._qt_window.tabifyDockWidget(dw4, dw5)
         viewer.window._qt_window.tabifyDockWidget(dw5, dw_mesh)
         viewer.window._qt_window.tabifyDockWidget(dw_mesh, dw_protein_loader)

--- a/src/surface_morphometrics_gui/utils/script_resolver.py
+++ b/src/surface_morphometrics_gui/utils/script_resolver.py
@@ -18,6 +18,10 @@ DISTANCES_ORIENTATIONS = "distances_orientations"
 # Thickness is two steps: sample tomogram density along normals, then fit it.
 SAMPLE_DENSITY = "sample_density"
 MEASURE_THICKNESS = "measure_thickness"
+# Optional density-guided mesh refinement (after pycurv, before distances):
+# refine_mesh iterates, then accept_refinement commits a chosen iteration.
+REFINE_MESH = "refine_mesh"
+ACCEPT_REFINEMENT = "accept_refinement"
 
 
 def results_dir(work_dir_field, exp_name):

--- a/src/surface_morphometrics_gui/utils/script_resolver.py
+++ b/src/surface_morphometrics_gui/utils/script_resolver.py
@@ -15,6 +15,9 @@ from pathlib import Path
 MAKE_MESHES = "make_meshes"
 PYCURV = "pycurv"
 DISTANCES_ORIENTATIONS = "distances_orientations"
+# Thickness is two steps: sample tomogram density along normals, then fit it.
+SAMPLE_DENSITY = "sample_density"
+MEASURE_THICKNESS = "measure_thickness"
 
 
 def results_dir(work_dir_field, exp_name):

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -58,3 +58,59 @@ class TestCheckAndArchiveOutputs:
             None, results_dir, config_path=None,
             file_patterns=["*.csv"], exclude_patterns=["*AVV*"]
         ) is True
+
+    def test_distance_excludes_refinement_artifacts(self, tmp_path):
+        """The distance step must not treat mesh-refinement outputs (which
+        share the results/ dir) as prior distance results."""
+        from utils.archive_utils import check_and_archive_outputs
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        # Artifacts left in results/ by the refinement step
+        for name in [
+            "T_IMM_refinement_convergence.png",
+            "T_OMM_refinement_convergence.png",
+            "T_IMM_profile_evolution.png",
+            "T_IMM_refinement_stats.csv",
+            "T_OMM_refinement_stats.csv",
+            "T_IMM_profile_iter3.png",
+            "T_IMM_samples_iter3.png",
+            "T_IMM_refined_iter1.lightweight_sampling.csv",
+        ]:
+            (results_dir / name).write_text("x")
+
+        # Same patterns/excludes as distance_tab.py
+        refinement_excludes = [
+            "*_refinement_*", "*_profile_evolution*",
+            "*_profile_iter*", "*_samples_iter*", "*lightweight*",
+        ]
+        assert check_and_archive_outputs(
+            None, results_dir, config_path=None,
+            file_patterns=["*.csv", "*.svg", "*.png"],
+            exclude_patterns=["*AVV*", "*VV*", "*.gt", "*_runtimes.csv"] + refinement_excludes,
+        ) is True
+
+    def test_distance_still_detects_real_outputs(self, tmp_path):
+        """A genuine distance-measurement CSV must still trigger the prompt."""
+        from utils.archive_utils import check_and_archive_outputs
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        (results_dir / "T_refinement_stats.csv").write_text("x")  # excluded
+        (results_dir / "T_IMM_OMM_distances.csv").write_text("x")  # real output
+
+        refinement_excludes = [
+            "*_refinement_*", "*_profile_evolution*",
+            "*_profile_iter*", "*_samples_iter*", "*lightweight*",
+        ]
+        with patch("utils.archive_utils.QMessageBox") as mock_mb:
+            instance = MagicMock()
+            mock_mb.return_value = instance
+            mock_mb.Cancel = "cancel"
+            cancel_btn = MagicMock()
+            instance.addButton.side_effect = [MagicMock(), MagicMock(), cancel_btn]
+            instance.clickedButton.return_value = cancel_btn
+            result = check_and_archive_outputs(
+                MagicMock(), results_dir, config_path=None,
+                file_patterns=["*.csv", "*.svg", "*.png"],
+                exclude_patterns=["*AVV*", "*VV*", "*.gt", "*_runtimes.csv"] + refinement_excludes,
+            )
+            assert result is False  # prompt shown, user cancelled

--- a/tests/test_refinement_tab.py
+++ b/tests/test_refinement_tab.py
@@ -1,0 +1,67 @@
+"""Tests for RefinementWidget."""
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from ruamel.yaml import YAML
+
+
+@pytest.mark.gui
+class TestRefinementWidget:
+    def _make_widget(self, qapp, mock_experiment_manager):
+        from jobs.refinement_tab import RefinementWidget
+        # Prevent _on_config_loaded from running during init.
+        mock_experiment_manager.config_loaded = MagicMock()
+        mock_experiment_manager.current_config = None
+        return RefinementWidget(mock_experiment_manager)
+
+    def test_creation_defaults(self, qapp, mock_experiment_manager):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        assert w.iterations_input.value == 6
+        assert w.damping_input.value == 0.9
+        assert w.average_radius_input.value == 25.0
+        assert w.max_offset_input.value == 8.0
+        assert w.xcorr_iterations_input.value == 3
+        assert w.monolayer_input.value is False
+        assert w.smooth_offsets_input.value is True
+
+    def test_on_config_loaded_collapses_xcorr_list(self, qapp, mock_experiment_manager):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        mock_experiment_manager.current_config = {
+            "mesh_refinement": {"iterations": 8, "xcorr_iterations": [1, 2, 3, 4]},
+        }
+        w._on_config_loaded()
+        assert w.iterations_input.value == 8
+        # A list of iteration numbers collapses to the "first N" form.
+        assert w.xcorr_iterations_input.value == 4
+
+    def test_update_config_writes_refinement_keys(self, qapp, mock_experiment_manager, tmp_path):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        mock_experiment_manager.current_config = {
+            "segmentation_values": {"ER": 1, "PM": 2},
+            "curvature_measurements": {"radius_hit": 9},
+        }
+        mock_experiment_manager.work_dir.value = str(tmp_path)
+        mock_experiment_manager.experiment_name.currentText.return_value = "exp"
+        mock_experiment_manager.cores_input.value.return_value = 4
+        (tmp_path / "exp").mkdir()
+        w.tomo_dir_input.value = str(tmp_path / "tomos")
+        w.iterations_input.value = 5
+        w.xcorr_iterations_input.value = 2
+
+        config_path = w._update_config()
+
+        yaml = YAML()
+        with open(config_path) as f:
+            cfg = yaml.load(f)
+        ref = cfg["mesh_refinement"]
+        assert ref["iterations"] == 5
+        assert ref["damping_factor"] == 0.9
+        assert ref["average_radius"] == 25.0
+        assert ref["max_total_offset"] == 8.0
+        # Written as an int ("first N iterations"), which the CLI accepts.
+        assert ref["xcorr_iterations"] == 2
+        assert ref["monolayer"] is False
+        assert cfg["tomo_dir"].endswith("/")
+        # work_dir must end in a separator for the CLI's string concatenation.
+        assert cfg["work_dir"].endswith("/")

--- a/tests/test_thickness_tab.py
+++ b/tests/test_thickness_tab.py
@@ -1,0 +1,64 @@
+"""Tests for ThicknessWidget."""
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from ruamel.yaml import YAML
+
+
+@pytest.mark.gui
+class TestThicknessWidget:
+    def _make_widget(self, qapp, mock_experiment_manager):
+        from jobs.thickness_tab import ThicknessWidget
+        # Prevent _on_config_loaded from running during init.
+        mock_experiment_manager.config_loaded = MagicMock()
+        mock_experiment_manager.current_config = None
+        return ThicknessWidget(mock_experiment_manager)
+
+    def test_creation_defaults(self, qapp, mock_experiment_manager):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        assert w.sample_spacing_input.value == 0.25
+        assert w.scan_range_input.value == 10.0
+        assert w.average_radius_input.value == 12.0
+        assert w.fit_curve_input.value is True
+
+    def test_components_from_segmentation_values(self, qapp, mock_experiment_manager):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        mock_experiment_manager.current_config = {"segmentation_values": {"ER": 1, "PM": 2}}
+        w._populate_components()
+        # All components pre-checked when nothing is saved yet.
+        assert sorted(w._selected_components()) == ["ER", "PM"]
+
+    def test_components_preselect_from_saved(self, qapp, mock_experiment_manager):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        mock_experiment_manager.current_config = {
+            "segmentation_values": {"ER": 1, "PM": 2},
+            "thickness_measurements": {"components": ["ER"]},
+        }
+        w._populate_components()
+        assert w._selected_components() == ["ER"]
+
+    def test_update_config_writes_thickness_keys(self, qapp, mock_experiment_manager, tmp_path):
+        w = self._make_widget(qapp, mock_experiment_manager)
+        mock_experiment_manager.current_config = {
+            "segmentation_values": {"ER": 1, "PM": 2},
+            "curvature_measurements": {"radius_hit": 9},
+        }
+        mock_experiment_manager.work_dir.value = str(tmp_path)
+        mock_experiment_manager.experiment_name.currentText.return_value = "exp"
+        mock_experiment_manager.cores_input.value.return_value = 4
+        (tmp_path / "exp").mkdir()
+        w.tomo_dir_input.value = str(tmp_path / "tomos")
+
+        config_path = w._update_config(["ER", "PM"])
+
+        yaml = YAML()
+        with open(config_path) as f:
+            cfg = yaml.load(f)
+        assert cfg["density_sampling"]["sample_spacing"] == 0.25
+        assert cfg["density_sampling"]["scan_range"] == 10.0
+        assert cfg["thickness_measurements"]["average_radius"] == 12.0
+        assert cfg["thickness_measurements"]["components"] == ["ER", "PM"]
+        assert cfg["tomo_dir"].endswith("/")
+        # work_dir must end in a separator for the CLI's string concatenation.
+        assert cfg["work_dir"].endswith("/")


### PR DESCRIPTION
Adds an optional **density-guided mesh refinement** step to the GUI and fixes a false-positive in the distance step's archive check. Also carries the earlier **thickness tab** commit, which had not yet been pushed or PR'd.

## Commits
1. `feat(thickness)` — membrane thickness measurement tab (sample_density → measure_thickness). *(pre-existing, not previously pushed)*
2. `fix(distance)` — ignore mesh-refinement artifacts in the archive check
3. `feat(refinement)` — density-guided mesh refinement tab

## Mesh refinement (new)
Optional step between PyCurv and Distances:
- `refine_mesh` iterates the surface toward the density-derived membrane center
- `accept_refinement` commits a chosen iteration
- New `RefinementWidget` tab, wired into `main.py` with its own dock; `REFINE_MESH`/`ACCEPT_REFINEMENT` script constants in `script_resolver`.

## Distance archive fix
The distance step's "existing results" check globbed `*.csv/*.svg/*.png` in `results/` and only excluded pycurv outputs (`*AVV*`, `*VV*`, `*.gt`, `*_runtimes.csv`). Mesh refinement writes convergence/profile-evolution plots and stats CSVs to the same dir — none matched, so the distance run falsely prompted Overwrite/Archive/Cancel over them. Added refinement-artifact patterns to the exclude list.

## Tests
- `test_refinement_tab.py` — new
- `test_archive_utils.py` — added cases for the false-positive and for still detecting a real distance output

All 10 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)